### PR TITLE
Prevent hard deletion of phones and agents

### DIFF
--- a/app/controllers/agents_controller.rb
+++ b/app/controllers/agents_controller.rb
@@ -2,7 +2,7 @@ class AgentsController < ApplicationController
   before_action :set_agent, only: [:show, :edit, :update, :destroy]
 
   def index
-    @agents = Agent.all
+    @agents = Agent.where(:deleted => false)
   end
 
   def show
@@ -42,7 +42,8 @@ class AgentsController < ApplicationController
   end
 
   def destroy
-    @agent.destroy
+    #@agent.destroy
+    @agent.update_attribute('deleted', true)
     respond_to do |format|
       format.html { redirect_to agents_url, notice: 'Agent was successfully destroyed.' }
       format.json { head :no_content }

--- a/app/controllers/phone_numbers_controller.rb
+++ b/app/controllers/phone_numbers_controller.rb
@@ -2,7 +2,7 @@ class PhoneNumbersController < ApplicationController
   before_action :set_phone_number, only: [:show, :edit, :update, :destroy]
 
   def index
-    @phone_numbers = PhoneNumber.all
+    @phone_numbers = PhoneNumber.where(:deleted => false)
   end
 
   def show
@@ -34,7 +34,8 @@ class PhoneNumbersController < ApplicationController
   end
 
   def destroy
-    @phone_number.destroy
+    #@phone_number.destroy
+    @phone_number.update_attribute('deleted', true)
 
     redirect_to phone_numbers_path
   end

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -2,6 +2,7 @@ class Agent < ApplicationRecord
   validates :name, presence: true
   validates :status, inclusion: { in: ['available', 'offline', 'on_call'] }
   validates :admin,  inclusion: { in: [true, false] }, allow_nil: true
+  validates :deleted, inclusion: { in: [true, false] }, allow_nil: true
 
   has_many :phone_calls
 end

--- a/app/models/phone_number.rb
+++ b/app/models/phone_number.rb
@@ -1,6 +1,7 @@
 class PhoneNumber < ApplicationRecord
   validates :number, presence: true
   validates :enabled, inclusion: { in: [true, false] }
+  validates :deleted, inclusion: { in: [true, false] }, allow_nil: true
 
   has_many :phone_calls
 end

--- a/db/migrate/20170731140211_create_phone_numbers.rb
+++ b/db/migrate/20170731140211_create_phone_numbers.rb
@@ -4,6 +4,7 @@ class CreatePhoneNumbers < ActiveRecord::Migration[5.1]
       t.string :number
       t.string :nickname
       t.boolean :enabled, default: true
+      t.boolean :deleted, default: false
 
       t.timestamps
     end

--- a/db/migrate/20180614151946_create_agents.rb
+++ b/db/migrate/20180614151946_create_agents.rb
@@ -4,6 +4,7 @@ class CreateAgents < ActiveRecord::Migration[5.1]
       t.string :name
       t.string :status
       t.boolean :admin, default: false
+      t.boolean :deleted, default: false
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,6 +16,7 @@ ActiveRecord::Schema.define(version: 20180614155847) do
     t.string "name"
     t.string "status"
     t.boolean "admin", default: false
+    t.boolean "deleted", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
@@ -34,6 +35,7 @@ ActiveRecord::Schema.define(version: 20180614155847) do
     t.string "number"
     t.string "nickname"
     t.boolean "enabled", default: true
+    t.boolean "deleted", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end


### PR DESCRIPTION
changed the schema in 'agent' and 'phone_number' by adding a boolean attribute called 'deleted' which is false by default and changes to true when user decides to destroy it, then change the 'destroy' method on both controllers from deleting the agent/phone_number to change its 'deleted' state to true.

finally filtering the agents/phone_numbers in 'index' method to select only the row where 'deleted' attribute is false.