### PR TITLE
Prevent agents from changing permissions

### DIFF
--- a/app/views/agents/_form.html.erb
+++ b/app/views/agents/_form.html.erb
@@ -21,11 +21,6 @@
     <%= form.text_field :status, id: :agent_status %>
   </div>
 
-  <div class="field">
-    <%= form.label :admin %>
-    <%= form.check_box :admin, id: :agent_admin, disabled: true %>
-  </div>
-
   <div class="actions">
     <%= form.submit %>
   </div>


### PR DESCRIPTION
didn't see any big purpose of having the admin checkbox because it's disabled always and any one can just inspect and change the value of the attribute 'disabled' from the source HTML.

if this is wrong we can make it only update the other columns but the admin column (didn't think of that in steps as i don't know much about the technology).